### PR TITLE
[#122189093] Fix ctl setup

### DIFF
--- a/jobs/collectd/templates/helpers/ctl_setup.sh
+++ b/jobs/collectd/templates/helpers/ctl_setup.sh
@@ -70,7 +70,7 @@ PIDFILE=$RUN_DIR/$JOB_NAME.pid
 # Add all packages' /bin & /sbin into $PATH
 for package_bin_dir in $(ls -d /var/vcap/packages/!(busybox)/*bin)
 do
-  export PATH=${package_bin_dir}:$PATH
+  export PATH=$PATH:${package_bin_dir}
 done
 
 export LD_LIBRARY_PATH=${LD_LIBRARY_PATH:-''} # default to empty

--- a/jobs/collectd/templates/helpers/ctl_setup.sh
+++ b/jobs/collectd/templates/helpers/ctl_setup.sh
@@ -30,18 +30,6 @@ redirect_output ${output_label}
 
 export HOME=${HOME:-/home/vcap}
 
-# Add all packages' /bin & /sbin into $PATH
-for package_bin_dir in $(ls -d /var/vcap/packages/!(busybox)/*bin)
-do
-  export PATH=${package_bin_dir}:$PATH
-done
-
-export LD_LIBRARY_PATH=${LD_LIBRARY_PATH:-''} # default to empty
-for package_bin_dir in $(ls -d /var/vcap/packages/!(busybox)/lib)
-do
-  export LD_LIBRARY_PATH=${package_bin_dir}:$LD_LIBRARY_PATH
-done
-
 # Setup log, run and tmp folders
 
 export RUN_DIR=/var/vcap/sys/run/$JOB_NAME
@@ -78,5 +66,17 @@ do
 done
 
 PIDFILE=$RUN_DIR/$JOB_NAME.pid
+
+# Add all packages' /bin & /sbin into $PATH
+for package_bin_dir in $(ls -d /var/vcap/packages/!(busybox)/*bin)
+do
+  export PATH=${package_bin_dir}:$PATH
+done
+
+export LD_LIBRARY_PATH=${LD_LIBRARY_PATH:-''} # default to empty
+for package_bin_dir in $(ls -d /var/vcap/packages/!(busybox)/lib)
+do
+  export LD_LIBRARY_PATH=${package_bin_dir}:$LD_LIBRARY_PATH
+done
 
 echo '$PATH' $PATH

--- a/jobs/collectd/templates/helpers/ctl_setup.sh
+++ b/jobs/collectd/templates/helpers/ctl_setup.sh
@@ -76,7 +76,10 @@ done
 export LD_LIBRARY_PATH=${LD_LIBRARY_PATH:-''} # default to empty
 for package_bin_dir in $(ls -d /var/vcap/packages/!(busybox)/lib)
 do
-  export LD_LIBRARY_PATH=${package_bin_dir}:$LD_LIBRARY_PATH
+  # do not include a package with ld-*.so as it is likely a rootfs
+  if [ -z "$(find ${package_bin_dir} -name 'ld-*.so' -o -name 'ld64-*.so')" ]; then
+      export LD_LIBRARY_PATH=${package_bin_dir}${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
+  fi
 done
 
 echo '$PATH' $PATH


### PR DESCRIPTION
### What

As it turns out, ctl_setup script is adding all the libraries of all packages deployed on a VM by BOSH into `LD_LIBRARY_PATH`. In case of concourse, this includes various resources, which are based on busybox. This then breaks commands like `mkdir` (segfault) - which breaks the start script in the end and monit is not able to run collectd, failing the VM deployment.

Move directory creation before `LD_LIBRARY_PATH` is exported. This way it works regardless of what packages are present on the system.
### Testing
- to verify that this doesn't break existing installation, switch your pipeline to deploy paas-collectd-bosh release from branch of this PR, deploy & check you still get metrics:

```
diff --git a/concourse/pipelines/create-bosh-cloudfoundry.yml b/concourse/pipelines/create-bosh-cloudfoundry.yml
index 723840e..7ff1a26 100644
--- a/concourse/pipelines/create-bosh-cloudfoundry.yml
+++ b/concourse/pipelines/create-bosh-cloudfoundry.yml
@@ -110,7 +110,10 @@ resources:
     type: git
     source:
       uri: https://github.com/alphagov/paas-collectd-boshrelease.git
-      tag_filter: {{cf_collectd_version}}
+      #tag_filter: {{cf_collectd_version}}
+      #FIXME: once this release has been tested remove the line below
+      # and uncomment the one above
+      branch: fix-ctl-setup

   - name: os-conf-boshrelease
     type: git
diff --git a/manifests/cf-manifest/manifest/runtime/runtime.yml b/manifests/cf-manifest/manifest/runtime/runtime.yml
index 3d5d8be..9551913 100644
--- a/manifests/cf-manifest/manifest/runtime/runtime.yml
+++ b/manifests/cf-manifest/manifest/runtime/runtime.yml
@@ -2,7 +2,10 @@ releases:
   - name: os-conf
     version: commit-a2bc2ab32248c8edf7c4790b33902893b1f4db66
   - name: collectd
-    version: 0.3
+    #version: 0.3
+    #FIXME: once this release has been tested remove the line below
+    # and uncomment the one above
+    version: test-version-1

 addons:
   - name: os-configuration
```
- to verify that this fixes startup issue, deploy this on concourse (see https://github.com/alphagov/paas-cf/pull/361), then downgrade to 0.3 version and see it fail:

```
  - name: collectd
    sha1: cd58286ff328d3dcd51507a434f010225e5179ca
    url: https://github.com/alphagov/paas-collectd-boshrelease/releases/download/0.3/collectd-0.3.tgz
```
### After merge

Tag master as 0.4. Create a 0.4 release here on github and add the tarball to it.
### Who

not @mtekel or @HenryTK 
